### PR TITLE
version 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,11 @@
 
 This library helps build a satellite architecture of a base station and satellite sensors. A protobuf-based packet system is used to allow satellite devices to send information about themselves and to send readings. This library is meant to work with the [og3](https://github.com/chl33/og3) library for ESP projects, using the Arduino framework with [Platformio](https://platformio.org/).
 
+This library is used by these projects:
+- [LoRa133](https://github.com/chl33/LoRa133)
+- [Garden133](https://github.com/chl33/Garden133)
+
+Please see the [Introducing Garden133](https://selectiveappeal.org/posts/garden133/) blog post.
+for a project overview.
+
 This library is still a work in progress.

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -66,14 +66,17 @@ class IntSensor : public Sensor {
 
 class Device {
  public:
-  Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, ModuleSystem* module_system,
-         HADiscovery* ha_discovery, uint16_t seq_id, VariableGroup& cvg);
+  Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, const char* device_type,
+         ModuleSystem* module_system, HADiscovery* ha_discovery, uint16_t seq_id,
+         VariableGroup& cvg);
 
   const std::string& name() const { return m_name; }
   const char* cname() const { return name().c_str(); }
   const std::string& device_id() const { return m_device_id; }
   const char* cdevice_id() const { return device_id().c_str(); }
   const std::string& manufacturer() const { return m_manufacturer; }
+  const std::string& device_type() const { return m_device_type; }
+  const char* cdevice_type() const { return device_type().c_str(); }
   const unsigned dropped_packets() const { return m_dropped_packets.value(); }
   bool is_disabled() const { return m_disabled.value(); }
   void set_disabled(bool disabled) { m_disabled = disabled; }
@@ -112,6 +115,7 @@ class Device {
   const std::string m_name;
   const std::string m_device_id;
   const std::string m_manufacturer;
+  const std::string m_device_type;
   uint16_t m_seq_id;
   HADiscovery* m_discovery;
   VariableGroup m_vg;

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3x-satellite",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A satellite comms architecture for chl33/og3",
     "keywords": "esp32, esp8266",
     "authors": [

--- a/proto/satellite.proto
+++ b/proto/satellite.proto
@@ -54,6 +54,7 @@ message Device {
   string name = 3 [ (nanopb).max_length = 15 ];
   Version hardware_version = 4;
   Version software_version = 5;
+  string device_type = 6 [ (nanopb).max_length = 15 ];
 }
 
 message Packet {

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -47,12 +47,6 @@ std::string _manufacturer(uint32_t id) {
   return buffer;
 }
 
-std::string _device_name(const char* name, uint32_t device_id) {
-  char buffer[80];
-  const auto len = snprintf(buffer, sizeof(buffer), "%s %x", name, device_id);
-  return std::string(buffer, len);
-}
-
 std::string _device_id(const char* name, uint32_t device_id) {
   char buffer[80];
   const auto len = snprintf(buffer, sizeof(buffer), "%s_%x", name, device_id);
@@ -108,13 +102,14 @@ IntSensor::IntSensor(const char* name, const char* device_class, const char* uni
   addHAEntry(entry);
 }
 
-Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id,
+Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, const char* device_type,
                ModuleSystem* module_system, HADiscovery* ha_discovery, uint16_t seq_id,
                VariableGroup& cvg)
     : m_device_id_num(device_id_num),
-      m_name(_device_name(name, device_id_num)),
+      m_name(name),
       m_device_id(_device_id(name, device_id_num)),
       m_manufacturer(_manufacturer(mfg_id)),
+      m_device_type(device_type),
       m_seq_id(seq_id),
       m_discovery(ha_discovery),
       m_vg(m_name.c_str(), m_device_id.c_str()),
@@ -130,6 +125,9 @@ Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id,
     entry.device_name = cname();
     entry.device_id = cdevice_id();
     entry.manufacturer = manufacturer().c_str();
+    if (!m_device_type.empty()) {
+      entry.model = cdevice_type();
+    }
     char entry_name[80];
     make_entry_name(entry_name, sizeof(entry_name), cname(), var.name());
     entry.entry_name = entry_name;


### PR DESCRIPTION
- Add device_type to device definition in satellite protocol
- Device name in MQTT now is directly the device name in the protobuf, so these should be unique for each device attached to the base station. This allows device names to be more descriptive in Home Assistant.
- Update README