### PR TITLE
base-station: support setting sensor values as 'failed'

### DIFF
--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -47,6 +47,7 @@ class FloatSensor : public Sensor {
 
   FloatVariable& value() { return m_value; }
   const FloatVariable& value() const { return m_value; }
+  void set_failed() { m_value.setFailed(); }
 
  private:
   FloatVariable m_value;
@@ -59,6 +60,7 @@ class IntSensor : public Sensor {
 
   Variable<int>& value() { return m_value; }
   const Variable<int>& value() const { return m_value; }
+  void set_failed() { m_value.setFailed(); }
 
  private:
   Variable<int> m_value;
@@ -80,6 +82,8 @@ class Device {
   const unsigned dropped_packets() const { return m_dropped_packets.value(); }
   bool is_disabled() const { return m_disabled.value(); }
   void set_disabled(bool disabled) { m_disabled = disabled; }
+
+  void setAllSensorReadingsFailed();
 
   FloatSensor* float_sensor(unsigned id) {
     auto iter = m_id_to_float_sensor.find(id);

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3x-satellite",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "A satellite comms architecture for chl33/og3",
     "keywords": "esp32, esp8266",
     "authors": [

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -155,4 +155,13 @@ void Device::got_packet(uint16_t seq_id, int rssi) {
   m_rssi = rssi;
 }
 
+void Device::setAllSensorReadingsFailed() {
+  for (auto& iter : m_id_to_float_sensor) {
+    iter.second->set_failed();
+  }
+  for (auto& iter : m_id_to_int_sensor) {
+    iter.second->set_failed();
+  }
+}
+
 }  // namespace og3::base_station


### PR DESCRIPTION
This is to help base stations to set all values as failed before reading a packet, so that values not in a packet will not go into JSON/MQTT messages.