### PR TITLE
V0 6 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/platformio-tests.yaml
+++ b/.github/workflows/platformio-tests.yaml
@@ -4,21 +4,43 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout og3x-satellite
+        uses: actions/checkout@v4
+        with:
+          path: og3x-satellite
+
+      - name: Checkout og3
+        uses: actions/checkout@v4
+        with:
+          repository: chl33/og3
+          path: og3
+
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 
+      - name: Setup symlinks for testing
+        run: |
+          cd og3x-satellite
+          mkdir -p lib
+          ln -s ../../og3 lib/og3
+          ln -s ../../og3/src src/og3_src
+          ln -s ../../og3/include src/og3_include
+
       - name: Do basic build
+        working-directory: og3x-satellite
         run: ./util/build.sh
 
       - name: Run PlatformIO tests
+        working-directory: og3x-satellite
         run: pio test -e native

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ uti/venv
 /include/og3/satellite.pb.h
 /src/satellite.pb.c
 /util/venv/
+/lib/og3
+/src/og3_src
+/src/og3_include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-03-24
+
+### Added
+- **Device Persistence**: Implemented static `saveAll()` and `loadAll()` methods in the `Device` class. Bridge applications can now "remember" their satellite network across reboots via a flash-based `devices.json` file.
+- **Version Tracking**: Added support for storing and retrieving hardware and software versions for each satellite device.
+- **Online Status**: Added `is_online()` getter to the `Device` class to support bridge UI indicators.
+
+### Changed
+- **Metadata Mutability**: Refactored the `Device` class to allow updating names, manufacturer IDs, and device types after initial discovery.
+- **og3 v0.6.1 Compatibility**: Updated to utilize the new `ConfigInterface::read_file/write_file` methods for robust persistence.
+
 ## [0.6.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ This library is used by these projects:
 
 Please see the [Introducing Garden133](https://selectiveappeal.org/posts/garden133/) blog post.
 for a project overview.
-
-This library is still a work in progress.

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -80,6 +80,9 @@ class Device {
   const std::string& device_type() const { return m_device_type; }
   const char* cdevice_type() const { return device_type().c_str(); }
   void set_device_type(const char* device_type) { m_device_type = device_type; }
+  unsigned packet_count() const { return m_packet_count; }
+  uint32_t last_packet_millis() const { return m_last_packet_millis; }
+  int rssi() const { return m_rssi.value(); }
   const unsigned dropped_packets() const { return m_dropped_packets.value(); }
   bool is_disabled() const { return m_disabled.value(); }
   void set_disabled(bool disabled) { m_disabled = disabled; }
@@ -140,6 +143,7 @@ class Device {
   VariableGroup m_vg;
   Variable<unsigned> m_dropped_packets;
   Variable<int> m_rssi;
+  unsigned m_packet_count = 0;
   std::map<unsigned, std::unique_ptr<FloatSensor>> m_id_to_float_sensor;
   std::map<unsigned, std::unique_ptr<IntSensor>> m_id_to_int_sensor;
   std::string m_str_disabled;

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -83,6 +83,12 @@ class Device {
   const std::string& device_type() const { return m_device_type; }
   const char* cdevice_type() const { return device_type().c_str(); }
   void set_device_type(const char* device_type) { m_device_type = device_type; }
+
+  const og3_Version& hardware_version() const { return m_hw_version; }
+  void set_hardware_version(const og3_Version& v) { m_hw_version = v; }
+  const og3_Version& software_version() const { return m_sw_version; }
+  void set_software_version(const og3_Version& v) { m_sw_version = v; }
+
   unsigned packet_count() const { return m_packet_count; }
   uint32_t last_packet_millis() const { return m_last_packet_millis; }
   uint32_t comms_timeout_millis() const { return m_comms_timeout_millis; }
@@ -107,8 +113,9 @@ class Device {
                       const std::map<uint32_t, std::unique_ptr<Device>>& devices);
 
   /** @brief Persistence: Load devices from a JSON file. */
-  using CreateDeviceFn = std::function<Device*(uint32_t id, const char* name, uint32_t mfg_id,
-                                               const char* type, uint32_t timeout_ms)>;
+  using CreateDeviceFn = std::function<Device*(
+      uint32_t id, const char* name, uint32_t mfg_id, const char* type, uint32_t timeout_ms,
+      const og3_Version& hw_version, const og3_Version& sw_version)>;
   static bool loadAll(const char* filename, ConfigInterface* config, CreateDeviceFn create_fn);
 
   FloatSensor* float_sensor(unsigned id) {
@@ -154,6 +161,8 @@ class Device {
   uint32_t m_mfg_id;
   std::string m_manufacturer;
   std::string m_device_type;
+  og3_Version m_hw_version;
+  og3_Version m_sw_version;
   uint16_t m_seq_id;
   HADiscovery* m_discovery;
   VariableGroup m_vg;

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -77,16 +77,20 @@ class Device {
   const std::string& device_id() const { return m_device_id; }
   const char* cdevice_id() const { return device_id().c_str(); }
   const std::string& manufacturer() const { return m_manufacturer; }
+  uint32_t mfg_id() const { return m_mfg_id; }
   const std::string& device_type() const { return m_device_type; }
   const char* cdevice_type() const { return device_type().c_str(); }
   void set_device_type(const char* device_type) { m_device_type = device_type; }
   unsigned packet_count() const { return m_packet_count; }
   uint32_t last_packet_millis() const { return m_last_packet_millis; }
+  uint32_t comms_timeout_millis() const { return m_comms_timeout_millis; }
   int rssi() const { return m_rssi.value(); }
   const unsigned dropped_packets() const { return m_dropped_packets.value(); }
   bool is_disabled() const { return m_disabled.value(); }
   void set_disabled(bool disabled) { m_disabled = disabled; }
   bool is_online() const { return m_is_online; }
+
+  uint32_t id_num() const { return m_device_id_num; }
 
   void addHAEntry(HADiscovery::Entry& entry, const char* sensor_name);
   void setAllSensorReadingsFailed();
@@ -95,6 +99,15 @@ class Device {
 
   bool isTimedOut() const;
   void set_comms_timeout_millis(uint32_t ms) { m_comms_timeout_millis = ms; }
+
+  /** @brief Persistence: Save all devices in the map to a JSON file. */
+  static bool saveAll(const char* filename, ConfigInterface* config,
+                      const std::map<uint32_t, std::unique_ptr<Device>>& devices);
+
+  /** @brief Persistence: Load devices from a JSON file. */
+  using CreateDeviceFn = std::function<Device*(uint32_t id, const char* name, uint32_t mfg_id,
+                                               const char* type, uint32_t timeout_ms)>;
+  static bool loadAll(const char* filename, ConfigInterface* config, CreateDeviceFn create_fn);
 
   FloatSensor* float_sensor(unsigned id) {
     auto iter = m_id_to_float_sensor.find(id);
@@ -136,6 +149,7 @@ class Device {
   const uint32_t m_device_id_num;
   const std::string m_name;
   const std::string m_device_id;
+  const uint32_t m_mfg_id;
   const std::string m_manufacturer;
   std::string m_device_type;
   uint16_t m_seq_id;

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -79,6 +79,7 @@ class Device {
   const std::string& manufacturer() const { return m_manufacturer; }
   const std::string& device_type() const { return m_device_type; }
   const char* cdevice_type() const { return device_type().c_str(); }
+  void set_device_type(const char* device_type) { m_device_type = device_type; }
   const unsigned dropped_packets() const { return m_dropped_packets.value(); }
   bool is_disabled() const { return m_disabled.value(); }
   void set_disabled(bool disabled) { m_disabled = disabled; }
@@ -133,7 +134,7 @@ class Device {
   const std::string m_name;
   const std::string m_device_id;
   const std::string m_manufacturer;
-  const std::string m_device_type;
+  std::string m_device_type;
   uint16_t m_seq_id;
   HADiscovery* m_discovery;
   VariableGroup m_vg;

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -74,10 +74,12 @@ class Device {
 
   const std::string& name() const { return m_name; }
   const char* cname() const { return name().c_str(); }
+  void set_name(const char* name) { m_name = name; }
   const std::string& device_id() const { return m_device_id; }
   const char* cdevice_id() const { return device_id().c_str(); }
   const std::string& manufacturer() const { return m_manufacturer; }
   uint32_t mfg_id() const { return m_mfg_id; }
+  void set_mfg_id(uint32_t mfg_id);
   const std::string& device_type() const { return m_device_type; }
   const char* cdevice_type() const { return device_type().c_str(); }
   void set_device_type(const char* device_type) { m_device_type = device_type; }
@@ -147,10 +149,10 @@ class Device {
 
  private:
   const uint32_t m_device_id_num;
-  const std::string m_name;
+  std::string m_name;
   const std::string m_device_id;
-  const uint32_t m_mfg_id;
-  const std::string m_manufacturer;
+  uint32_t m_mfg_id;
+  std::string m_manufacturer;
   std::string m_device_type;
   uint16_t m_seq_id;
   HADiscovery* m_discovery;

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -83,7 +83,13 @@ class Device {
   bool is_disabled() const { return m_disabled.value(); }
   void set_disabled(bool disabled) { m_disabled = disabled; }
 
+  void addHAEntry(HADiscovery::Entry& entry, const char* sensor_name);
   void setAllSensorReadingsFailed();
+
+  void setIsOnline(bool is_online);
+
+  bool isTimedOut() const;
+  void set_comms_timeout_millis(uint32_t ms) { m_comms_timeout_millis = ms; }
 
   FloatSensor* float_sensor(unsigned id) {
     auto iter = m_id_to_float_sensor.find(id);
@@ -136,6 +142,10 @@ class Device {
   std::map<unsigned, std::unique_ptr<IntSensor>> m_id_to_int_sensor;
   std::string m_str_disabled;
   BoolVariable m_disabled;
+  uint32_t m_last_packet_millis = 0;
+  bool m_is_online = false;
+  // TODO(chl33): How can this be configured??
+  uint32_t m_comms_timeout_millis = 15 * 60 * 1000;  // 15 minutes.
 };
 
 }  // namespace og3::base_station

--- a/include/og3/base-station.h
+++ b/include/og3/base-station.h
@@ -82,6 +82,7 @@ class Device {
   const unsigned dropped_packets() const { return m_dropped_packets.value(); }
   bool is_disabled() const { return m_disabled.value(); }
   void set_disabled(bool disabled) { m_disabled = disabled; }
+  bool is_online() const { return m_is_online; }
 
   void addHAEntry(HADiscovery::Entry& entry, const char* sensor_name);
   void setAllSensorReadingsFailed();

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3x-satellite",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "A satellite comms architecture for chl33/og3",
     "keywords": "esp32, esp8266",
     "authors": [
@@ -12,7 +12,7 @@
 	}
     ],
     "dependencies": {
-	"og3": "~0.6.0",
+	"og3": "~0.6.1",
 	"nanopb/Nanopb": "~0.4.91"
 
     },

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ build_flags =
 	-I src/og3_include
 lib_deps =
 	fabiobatsilva/ArduinoFake
-	symlink://../og3
+	chl33/og3@^0.6.1
 	${env.lib_deps}
 	unity
 lib_ignore =
@@ -48,12 +48,10 @@ lib_ignore =
 	Hash
 lib_compat_mode = off
 test_build_src = yes
-build_src_filter = +<src/*> -<src/device.pb.c> +<src/og3_src/*.cpp>
 build_type = debug
 
 [esp_base]
 framework = arduino
-build_src_filter = +<src/*> -<src/og3_src/*> -<src/og3_include/*>
 monitor_speed = 115200
 uploadProtocol = esptool
 uploadPort = /dev/ttyUSB0

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,6 @@ build_flags =
 	-I src/og3_include
 lib_deps =
 	fabiobatsilva/ArduinoFake
-	chl33/og3@^0.6.1
 	${env.lib_deps}
 	unity
 lib_ignore =
@@ -48,10 +47,12 @@ lib_ignore =
 	Hash
 lib_compat_mode = off
 test_build_src = yes
+build_src_filter = +<src/*> -<src/device.pb.c> +<src/og3_src/*.cpp>
 build_type = debug
 
 [esp_base]
 framework = arduino
+build_src_filter = +<src/*> -<src/og3_src/*> -<src/og3_include/*>
 monitor_speed = 115200
 uploadProtocol = esptool
 uploadPort = /dev/ttyUSB0

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,42 +9,51 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-src_dir = .
+default_envs = esp32dev
 
 [env]
 board_build.filesystem = littlefs
 build_flags =
         '-Wall'
 	'-Wno-deprecated'
-lib_extra_dirs =
-	~/Projects2
 lib_deps =
-	og3@^0.3.17
-	https://github.com/mathieucarbou/ESPAsyncWebServer
 	bakercp/CRC32@^2.0.0
 	bblanchon/ArduinoJson@^7.0.0
-	heman/AsyncMqttClient-esphome@^1.0.0
-	esphome/ESPAsyncWebServer-esphome@^3.0.0
 	nanopb/Nanopb
-	unity
-lib_ldf_mode = deep
+lib_ldf_mode = deep+
+lib_archive = no
 check_tool = clangtidy
 
 [env:native]
 platform = native
+lib_archive = no
 build_flags =
 	${env.build_flags}
 	'-DNATIVE'
+	-I include
+	-I src/og3_include
 lib_deps =
-	${env.lib_deps}
 	fabiobatsilva/ArduinoFake
+	symlink://../og3
+	${env.lib_deps}
+	unity
+lib_ignore =
+	PsychicMqttClient
+	PsychicHttp
+	ESPAsyncWebServer-esphome
+	ESPAsyncWebServer
+	AsyncMqttClient-esphome
+	AsyncMqttClient
+	ESPAsyncTCP
+	Hash
+lib_compat_mode = off
 test_build_src = yes
-build_src_filter = +<src/*> -<src/device.pb.c>
+build_src_filter = +<src/*> -<src/device.pb.c> +<src/og3_src/*.cpp>
 build_type = debug
 
 [esp_base]
 framework = arduino
-build_src_filter = +<src/*>
+build_src_filter = +<src/*> -<src/og3_src/*> -<src/og3_include/*>
 monitor_speed = 115200
 uploadProtocol = esptool
 uploadPort = /dev/ttyUSB0
@@ -53,12 +62,20 @@ uploadPort = /dev/ttyUSB0
 extends = esp_base
 platform = espressif32
 monitor_filters = esp32_exception_decoder
+lib_deps =
+	${env.lib_deps}
+	elims/PsychicMqttClient@^0.2.4
+	hoeken/PsychicHttp@^2.1.1
 
 [env:d1_mini]
 extends = esp_base
 platform = espressif8266
 board = d1_mini
 monitor_filters = esp8266_exception_decoder
+lib_deps =
+	${env.lib_deps}
+	ESP32Async/ESPAsyncWebServer@3.6.0
+	heman/AsyncMqttClient-esphome@^1.0.0
 
 [env:esp32dev]
 extends = esp32_base

--- a/proto/satellite.proto
+++ b/proto/satellite.proto
@@ -55,6 +55,7 @@ message Device {
   Version hardware_version = 4;
   Version software_version = 5;
   string device_type = 6 [ (nanopb).max_length = 15 ];
+  uint32 timeout_secs = 7;
 }
 
 message Packet {

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -149,7 +149,7 @@ bool Device::saveAll(const char* filename, ConfigInterface* config,
     obj["swMin"] = device->software_version().minor;
     obj["swPat"] = device->software_version().patch;
   }
-  String content;
+  std::string content;
   serializeJson(doc, content);
   return config->write_file(filename, content.c_str());
 }
@@ -163,7 +163,7 @@ bool Device::loadAll(const char* filename, ConfigInterface* config, CreateDevice
     return false;
   }
   JsonDocument doc;
-  DeserializationError error = deserializeJson(doc, content);
+  DeserializationError error = deserializeJson(doc, content.c_str());
   if (error) {
     return false;
   }

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -65,12 +65,6 @@ Sensor::Sensor(const char* name, const char* device_class, const char* units, De
       m_device(device) {}
 
 void Sensor::addHAEntry(HADiscovery::Entry& entry) {
-  entry.device_name = m_device->cname();
-  entry.device_id = m_device->cdevice_id();
-  entry.manufacturer = m_device->manufacturer().c_str();
-  char entry_name[80];
-  make_entry_name(entry_name, sizeof(entry_name), m_device->cname(), name().c_str());
-  entry.entry_name = entry_name;
   switch (m_state_class) {
     case og3_Sensor_StateClass_STATE_CLASS_UNSPECIFIED:
       break;
@@ -78,12 +72,7 @@ void Sensor::addHAEntry(HADiscovery::Entry& entry) {
       entry.state_class = "measurement";
       break;
   }
-  // entry.software
-  entry.via_device = m_device->ha_discovery().deviceId();
-  // entry.icon
-  JsonDocument json;
-  // TODO(chrishl): should bookkeep and send again if this fails.
-  m_device->ha_discovery().addEntry(&json, entry);
+  m_device->addHAEntry(entry, name().c_str());
 }
 
 FloatSensor::FloatSensor(const char* name, const char* device_class, const char* units,
@@ -120,21 +109,13 @@ Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, const 
   JsonDocument json;
   auto make_ha_entry = [&json, this](const VariableBase& var, const char* device_type,
                                      const char* device_class) {
-    json.clear();
     HADiscovery::Entry entry(var, device_type, device_class);
-    entry.device_name = cname();
-    entry.device_id = cdevice_id();
-    entry.manufacturer = manufacturer().c_str();
-    if (!m_device_type.empty()) {
-      entry.model = cdevice_type();
-    }
-    char entry_name[80];
-    make_entry_name(entry_name, sizeof(entry_name), cname(), var.name());
-    entry.entry_name = entry_name;
-    m_discovery->addEntry(&json, entry);
+    entry.state_class = "measurement";
+    addHAEntry(entry, var.name());
   };
   make_ha_entry(m_dropped_packets, ha::device_type::kSensor, nullptr);
   make_ha_entry(m_rssi, ha::device_type::kSensor, ha::device_class::sensor::kSignalStrength);
+  setIsOnline(true);
 }
 
 void Device::got_packet(uint16_t seq_id, int rssi) {
@@ -153,8 +134,29 @@ void Device::got_packet(uint16_t seq_id, int rssi) {
   }
   m_seq_id = seq_id;
   m_rssi = rssi;
+  m_last_packet_millis = millis();
 }
 
+void Device::addHAEntry(HADiscovery::Entry& entry, const char* sensor_name) {
+  entry.device_name = cname();
+  entry.device_id = cdevice_id();
+  entry.manufacturer = manufacturer().c_str();
+  if (!m_device_type.empty()) {
+    entry.model = cdevice_type();
+  }
+  char entry_name[80];
+  make_entry_name(entry_name, sizeof(entry_name), cname(), sensor_name);
+  entry.entry_name = entry_name;
+  entry.software = cname();
+  entry.via_device = ha_discovery().deviceId();
+  char availability[80];
+  snprintf(availability, sizeof(availability), "~/%s_connection", cname());
+  entry.availability = availability;
+  // entry.icon
+  JsonDocument json;
+  // TODO(chrishl): should bookkeep and send again if this fails.
+  ha_discovery().addEntry(&json, entry);
+}
 void Device::setAllSensorReadingsFailed() {
   for (auto& iter : m_id_to_float_sensor) {
     iter.second->set_failed();
@@ -162,6 +164,31 @@ void Device::setAllSensorReadingsFailed() {
   for (auto& iter : m_id_to_int_sensor) {
     iter.second->set_failed();
   }
+}
+
+void Device::setIsOnline(bool is_online) {
+  if (is_online == m_is_online) {
+    return;
+  }
+  m_is_online = is_online;
+  if (!is_online) {
+    setAllSensorReadingsFailed();
+  }
+  auto mqtt = m_discovery->mqttManager();
+  if (!mqtt) {
+    return;
+  }
+  char availability[80];
+  snprintf(availability, sizeof(availability), "%s_connection", cname());
+  mqtt->mqttSend(mqtt->topic(availability).c_str(), is_online ? "online" : "offline");
+}
+
+bool Device::isTimedOut() const {
+  if (!m_is_online) {
+    return true;
+  }
+  const uint32_t elapsed = millis() - m_last_packet_millis;
+  return elapsed > m_comms_timeout_millis;
 }
 
 }  // namespace og3::base_station

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -101,6 +101,8 @@ Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, const 
       m_mfg_id(mfg_id),
       m_manufacturer(_manufacturer(mfg_id)),
       m_device_type(device_type),
+      m_hw_version(og3_Version_init_zero),
+      m_sw_version(og3_Version_init_zero),
       m_seq_id(seq_id),
       m_discovery(ha_discovery),
       m_vg(m_name.c_str(), m_device_id.c_str()),
@@ -140,6 +142,12 @@ bool Device::saveAll(const char* filename, ConfigInterface* config,
     obj["mfg"] = device->mfg_id();
     obj["type"] = device->device_type();
     obj["timeout"] = device->comms_timeout_millis();
+    obj["hwMaj"] = device->hardware_version().major;
+    obj["hwMin"] = device->hardware_version().minor;
+    obj["hwPat"] = device->hardware_version().patch;
+    obj["swMaj"] = device->software_version().major;
+    obj["swMin"] = device->software_version().minor;
+    obj["swPat"] = device->software_version().patch;
   }
   String content;
   serializeJson(doc, content);
@@ -161,7 +169,9 @@ bool Device::loadAll(const char* filename, ConfigInterface* config, CreateDevice
   }
   JsonArray arr = doc.as<JsonArray>();
   for (JsonObject obj : arr) {
-    create_fn(obj["id"], obj["name"], obj["mfg"], obj["type"], obj["timeout"]);
+    og3_Version hw = {obj["hwMaj"], obj["hwMin"], obj["hwPat"]};
+    og3_Version sw = {obj["swMaj"], obj["swMin"], obj["swPat"]};
+    create_fn(obj["id"], obj["name"], obj["mfg"], obj["type"], obj["timeout"], hw, sw);
   }
   return true;
 }

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 #include <og3/base-station.h>
+#include <og3/config_interface.h>
 
 namespace og3::base_station {
 namespace {
@@ -97,6 +98,7 @@ Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, const 
     : m_device_id_num(device_id_num),
       m_name(name),
       m_device_id(_device_id(name, device_id_num)),
+      m_mfg_id(mfg_id),
       m_manufacturer(_manufacturer(mfg_id)),
       m_device_type(device_type),
       m_seq_id(seq_id),
@@ -116,6 +118,47 @@ Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, const 
   make_ha_entry(m_dropped_packets, ha::device_type::kSensor, nullptr);
   make_ha_entry(m_rssi, ha::device_type::kSensor, ha::device_class::sensor::kSignalStrength);
   setIsOnline(true);
+}
+
+bool Device::saveAll(const char* filename, ConfigInterface* config,
+                     const std::map<uint32_t, std::unique_ptr<Device>>& devices) {
+  if (!config) {
+    return false;
+  }
+  JsonDocument doc;
+  JsonArray arr = doc.to<JsonArray>();
+  for (auto& iter : devices) {
+    const auto& device = iter.second;
+    JsonObject obj = arr.add<JsonObject>();
+    obj["id"] = device->id_num();
+    obj["name"] = device->name();
+    obj["mfg"] = device->mfg_id();
+    obj["type"] = device->device_type();
+    obj["timeout"] = device->comms_timeout_millis();
+  }
+  String content;
+  serializeJson(doc, content);
+  return config->write_file(filename, content.c_str());
+}
+
+bool Device::loadAll(const char* filename, ConfigInterface* config, CreateDeviceFn create_fn) {
+  if (!config) {
+    return false;
+  }
+  String content;
+  if (!config->read_file(filename, &content)) {
+    return false;
+  }
+  JsonDocument doc;
+  DeserializationError error = deserializeJson(doc, content);
+  if (error) {
+    return false;
+  }
+  JsonArray arr = doc.as<JsonArray>();
+  for (JsonObject obj : arr) {
+    create_fn(obj["id"], obj["name"], obj["mfg"], obj["type"], obj["timeout"]);
+  }
+  return true;
 }
 
 void Device::got_packet(uint16_t seq_id, int rssi) {

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -120,6 +120,11 @@ Device::Device(uint32_t device_id_num, const char* name, uint32_t mfg_id, const 
   setIsOnline(true);
 }
 
+void Device::set_mfg_id(uint32_t mfg_id) {
+  m_mfg_id = mfg_id;
+  m_manufacturer = _manufacturer(mfg_id);
+}
+
 bool Device::saveAll(const char* filename, ConfigInterface* config,
                      const std::map<uint32_t, std::unique_ptr<Device>>& devices) {
   if (!config) {

--- a/src/base-station.cpp
+++ b/src/base-station.cpp
@@ -135,6 +135,7 @@ void Device::got_packet(uint16_t seq_id, int rssi) {
   m_seq_id = seq_id;
   m_rssi = rssi;
   m_last_packet_millis = millis();
+  m_packet_count += 1;
 }
 
 void Device::addHAEntry(HADiscovery::Entry& entry, const char* sensor_name) {

--- a/src/satellite.cpp
+++ b/src/satellite.cpp
@@ -124,6 +124,7 @@ void PacketSender::start_packet(og3_Packet& packet, bool update_device) {
   packet.device.software_version.patch = m_device->software_version.patch;
   packet.device.has_hardware_version = true;
   packet.device.has_software_version = true;
+  SETSTR(packet.device.device_type, m_device->device_type);
   packet.device.timeout_secs = m_device->timeout_secs;
 }
 

--- a/src/satellite.cpp
+++ b/src/satellite.cpp
@@ -124,6 +124,7 @@ void PacketSender::start_packet(og3_Packet& packet, bool update_device) {
   packet.device.software_version.patch = m_device->software_version.patch;
   packet.device.has_hardware_version = true;
   packet.device.has_software_version = true;
+  packet.device.timeout_secs = m_device->timeout_secs;
 }
 
 }  // namespace og3::satellite

--- a/util/build.sh
+++ b/util/build.sh
@@ -3,7 +3,7 @@
 set -e
 here="$(readlink -f "$(dirname "$0")")"
 cd "${here}"/..
-pio pkg install
+pio pkg install -e native
 if [ ! -d ./util/venv ]; then
     python3 -m venv ./util/venv
     . ./util/venv/bin/activate


### PR DESCRIPTION
### Added
- **Device Persistence**: Implemented static `saveAll()` and `loadAll()` methods in the `Device` class. Bridge applications can now "remember" their satellite network across reboots via a flash-based `devices.json` file.
- **Version Tracking**: Added support for storing and retrieving hardware and software versions for each satellite device.
- **Online Status**: Added `is_online()` getter to the `Device` class to support bridge UI indicators.

### Changed
- **Metadata Mutability**: Refactored the `Device` class to allow updating names, manufacturer IDs, and device types after initial discovery.
- **og3 v0.6.1 Compatibility**: Updated to utilize the new `ConfigInterface::read_file/write_file` methods for robust persistence.